### PR TITLE
Fix disconnected USB devices.

### DIFF
--- a/src/xenusbdevice/xenif.cpp
+++ b/src/xenusbdevice/xenif.cpp
@@ -3026,6 +3026,14 @@ XenDpc(
 
         usbif_shadow_ex_t *shadow = &fdoContext->Xen->Shadows[response->id];
         ASSERT(shadow->Tag == SHADOW_TAG);
+
+        if (response->status == USBIF_RSP_USB_INVALID)
+        {
+            TraceEvents(TRACE_LEVEL_WARNING, TRACE_URB,
+                __FUNCTION__":Invalid response received from the backend\n");
+            continue;
+        }
+
         if (!shadow->InUse)
         {
             //
@@ -3148,14 +3156,6 @@ XenDpc(
             {
                 PURB Urb = URB_FROM_REQUEST(Request);
                 Urb->UrbHeader.Status = usbdStatus;
-
-                if (response->status == USBIF_RSP_USB_INVALID)
-                {
-                    //
-                    // debug this.
-                    //
-                    TraceUsbIfRequest(fdoContext, &shadow->req);
-                }
 
                 NtStatus = PostProcessUrb(
                                fdoContext,


### PR DESCRIPTION
This PR re-enables the FdoEvtTimerFunc to check the status of our Xen backend. If not operational, we cleanup the disconnected device. This PR also moves the check for an invalid URB response from the backend further up on the XenDPC loop. When we get a bad response we don't want this processed and we just continue moving forward with other requests.

The basic symptoms are that when a CAC is removed from the CAC reader assigned to a guest VM, and then re-inserted after some time, the CAC reader is not responsive. The CAC is not read by the reader. This is an intermittent problem. It may occur several times a day, or it may not occur for several days.

When does occur, the Windows system event log reports a critical error indicating that the SmartCard reader is offline due to a user-mode driver crash. This same behavior can be readily reproduced by physically unplugging and then re-plugging in the USB CAC reader. Usually, within one or two repetitions the problem will occur. (To be clear, the operators in the field are not unplugging and re-plugging their readers; this is just to accelerate generating the issue. This is a simple test that could be done to simulate the problem.)

Without this PR, a SmartCard hotplug would survive at most 3-5 times before it either crashes the kernel driver or causes a BSOD. With this PR I was able to hotplug a SmartCard more than 40 times without issue.

Signed-off-by: Richard Turner <turnerr@ainfosec.com>